### PR TITLE
피드백 반영

### DIFF
--- a/src/component/home/OurTeam.js
+++ b/src/component/home/OurTeam.js
@@ -4,6 +4,7 @@ import {viewHeightCalc} from "../../lib/viewportCalculate";
 import {Fab} from "@mui/material"
 import KeyboardDoubleArrowRightIcon from '@mui/icons-material/KeyboardDoubleArrowRight';
 import {useNavigate} from "react-router-dom";
+import dayjs from "dayjs";
 
 export default function OurTeam() {
     const navigate = useNavigate();
@@ -17,7 +18,7 @@ export default function OurTeam() {
                                 <div className='TeamName'>{item.partName}</div>
                                 <div className='TeamDescription'>{item.description}</div>
                             </TextWrapper>
-                            <Button onClick={()=>navigate(`../faq/${item.partName.toLowerCase()}`)}>
+                            <Button onClick={()=>navigate(`../ourteam/${item.partName.toLowerCase()}?year=${dayjs().get('year')}`)}>
                                 <KeyboardDoubleArrowRightIcon fontSize="large"/>
                             </Button>
                         </TeamListItem>

--- a/src/component/ourteam/YearDropBox.js
+++ b/src/component/ourteam/YearDropBox.js
@@ -24,7 +24,7 @@ export default function YearDropBox({year, handleYearChange}) {
                 >
                     {
                         yearList.map((year, i) => (
-                            <MenuItem key={i} value={year}>{year}</MenuItem>
+                            <MenuItem key={i} value={year} sx={{justifyContent: "center"}}>{year}</MenuItem>
                         ))
                     }
                 </DropBox>
@@ -35,6 +35,7 @@ export default function YearDropBox({year, handleYearChange}) {
 
 const DropBox = styled(Select)`
   border-radius: 15px;
+  text-align: center;
   width: auto;
 
   & > *:first-child {
@@ -47,7 +48,7 @@ const DropBox = styled(Select)`
       padding: 4px 8px;
     }
   }
-
+  
   font-size: ${props => props.theme.fontSize.bigDesktop.caption};
   @media (max-width: 1800px) {
     font-size: ${props => props.theme.fontSize.desktop.caption};


### PR DESCRIPTION
데스크탑
1.홈페이지에 있는 아워팀에서 파트를 누르면 FAQ로 이동합니다 아워팀 페이지로 이동하도록 바뀌어야할 것 같아요

모바일
3. 아워팀에서 년도 글자가 중간 정렬되면 좋겠습니다! 현재는 왼쪽으로 쏠려있는 형태인데 중간으로 정렬된게 더 이쁠 것 같아요